### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: "0 0 * * 0"
+  
+jobs:
+  container-job:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        stable: [true]
+        crystal:
+          - 1.1.1
+          - 1.2.2
+          - 1.3.2
+          - 1.4.1
+          - 1.5.0
+        include:
+          - os: ubuntu-latest
+            crystal: nightly
+            stable: false
+          - os: macos-latest
+            crystal: nightly
+            stable: false
+    continue-on-error: ${{ !matrix.stable }}
+    runs-on: ${{ matrix.os }}
+    name: 'crystal: ${{ matrix.crystal }}, os: ${{ matrix.os }}'
+    steps:
+      - name: Download source
+        uses: actions/checkout@v2
+      - name: Install Crystal
+        uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+      - name: Cache shards
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/shards
+          key: ${{ runner.os }}-${{matrix.crystal}}-shards-${{ hashFiles('shard.yml') }}
+          restore-keys: ${{ runner.os }}-shards-
+      - name: Install shards
+        run: shards update
+      - name: Redis on ${{ runner.os }}
+        uses: shogo82148/actions-setup-redis@v1
+        id: main_redis
+        with:
+          redis-version: 6.2
+      - run: redis-cli info | grep version
+      - name: Run tests
+        run: crystal spec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,14 @@ jobs:
           restore-keys: ${{ runner.os }}-shards-
       - name: Install shards
         run: shards update
+
       - name: Redis on ${{ runner.os }}
         uses: shogo82148/actions-setup-redis@v1
         id: main_redis
         with:
           redis-version: 6.2
+
       - run: redis-cli info | grep version
+
       - name: Run tests
         run: crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/shard.yml
+++ b/shard.yml
@@ -4,13 +4,10 @@ version: 0.3.0
 dependencies:
   kemal-session:
     github: kemalcr/kemal-session
-    branch: master
-  pool:
-    github: ysbaddaden/pool
-    version: 0.2.3
+    version: ~> 1.0
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 1.8.0
+    version: ~> 2.8.0
 
 authors:
   - Rimas Silkaitis <neovintage@gmail.com>

--- a/src/kemal-session-redis.cr
+++ b/src/kemal-session-redis.cr
@@ -1,222 +1,228 @@
 require "uri"
 require "json"
 require "redis"
-require "pool/connection"
 require "kemal-session"
 
 module Kemal
-class Session
-  class RedisEngine < Engine
-    class StorageInstance
-      macro define_storage(vars)
-        JSON.mapping({
+  class Session
+    class RedisEngine < Engine
+      class StorageInstance
+        include JSON::Serializable
+
+        macro define_storage(vars)
           {% for name, type in vars %}
-            {{name.id}}s: Hash(String, {{type}}),
+            @[JSON::Field(key: "{{name.id}}s")]
+            getter {{name.id}}s : Hash(String, {{type}})
+
+            def {{name.id}}(k : String) : {{type}}
+              return @{{name.id}}s[k]
+            end
+
+            def {{name.id}}?(k : String) : {{type}}?
+              return @{{name.id}}s[k]?
+            end
+
+            def {{name.id}}(k : String, v : {{type}})
+              @{{name.id}}s[k] = v
+            end
+
+            def delete_{{name.id}}(k : String)
+              if @{{name.id}}s[k]?
+                @{{name.id}}s.delete(k)
+              end
+            end
           {% end %}
+
+          def initialize
+            {% for name, type in vars %}
+              @{{name.id}}s = Hash(String, {{type}}).new
+            {% end %}
+          end
+        end
+
+        define_storage({
+          int: Int32,
+          bigint: Int64,
+          string: String,
+          float: Float64,
+          bool: Bool,
+          object: Session::StorableObject::StorableObjectContainer
         })
+      end
 
-        {% for name, type in vars %}
-          @{{name.id}}s = Hash(String, {{type}}).new
-          getter {{name.id}}s
+      @redis  : Redis::PooledClient
+      @cache : StorageInstance
+      @cached_session_id : String
 
-          def {{name.id}}(k : String) : {{type}}
-            return @{{name.id}}s[k]
+      def initialize(host = "localhost", port = 6379, password = nil, database = 0, capacity = 20, timeout = 2.0, unixsocket = nil, pool = nil, key_prefix = "kemal:session:")
+        @redis = uninitialized Redis::PooledClient
+
+        if pool.nil?
+          @redis = Redis::PooledClient.new(
+            host: host,
+            port: port,
+            database: database,
+            unixsocket: unixsocket,
+            password: password,
+            pool_size: capacity,
+            pool_timeout: timeout
+          )
+          # @redis = ConnectionPool.new(capacity: capacity, timeout: timeout) do
+          #   Redis.new(
+              # host: host,
+              # port: port,
+              # database: database,
+              # unixsocket: unixsocket,
+              # password: password
+          #   )
+          # end
+        else
+          @redis = pool
+        end
+
+        @cache = StorageInstance.new
+        @key_prefix = key_prefix
+        @cached_session_id = ""
+      end
+
+      def run_gc
+        # Do Nothing. All the sessions should be set with the
+        # expiration option on the keys. So long as the redis instance
+        # hasn't been set up with maxmemory policy of noeviction
+        # then this should be fine. `noeviction` will cause the redis
+        # instance to fill up and keys will not expire from the instance
+      end
+
+      def prefix_session(session_id : String)
+        "#{@key_prefix}#{session_id}"
+      end
+
+      def parse_session_id(key : String)
+        key.sub(@key_prefix, "")
+      end
+
+      def load_into_cache(session_id)
+        @cached_session_id = session_id
+
+        @redis.pool.connection do |conn|
+          value = conn.get(prefix_session(session_id))
+          if !value.nil?
+            @cache = StorageInstance.from_json(value)
+          else
+            @cache = StorageInstance.new
+            conn.set(
+              prefix_session(session_id),
+              @cache.to_json,
+              ex: Session.config.timeout.total_seconds.to_i
+            )
           end
+        end
 
-          def {{name.id}}?(k : String) : {{type}}?
-            return @{{name.id}}s[k]?
-          end
+        @cache
+      end
 
-          def {{name.id}}(k : String, v : {{type}})
-            @{{name.id}}s[k] = v
-          end
-        {% end %}
-
-        def initialize
-          {% for name, type in vars %}
-            @{{name.id}}s = Hash(String, {{type}}).new
-          {% end %}
+      def save_cache
+        @redis.pool.connection do |conn|
+          conn.set(
+            prefix_session(@cached_session_id),
+            @cache.to_json,
+            ex: Session.config.timeout.total_seconds.to_i
+          )
         end
       end
 
-      define_storage({
+      def is_in_cache?(session_id)
+        return session_id == @cached_session_id
+      end
+
+      def create_session(session_id : String)
+        load_into_cache(session_id)
+      end
+
+      def get_session(session_id : String) : Session?
+        @redis.pool.connection do |conn|
+          value = conn.get(prefix_session(session_id))
+          return Session.new(session_id) if value
+        end
+      end
+
+      def destroy_session(session_id : String)
+        @redis.pool.connection do |conn|
+          conn.del(prefix_session(session_id))
+        end
+      end
+
+      def destroy_all_sessions
+        @redis.pool.connection do |conn|
+          cursor = 0
+          loop do
+            cursor, keys = conn.scan(cursor, "#{@key_prefix}*")
+            keys = keys.as(Array(Redis::RedisValue)).map(&.to_s)
+            keys.each do |key|
+              conn.del(key)
+            end
+            break if cursor == "0"
+          end
+        end
+      end
+
+      def all_sessions : Array(Session)
+        arr = [] of Session
+
+        each_session do |session|
+          arr << session
+        end
+
+        return arr
+      end
+
+      def each_session
+        @redis.pool.connection do |conn|
+          cursor = 0
+          loop do
+            cursor, keys = conn.scan(cursor, "#{@key_prefix}*")
+            keys = keys.as(Array(Redis::RedisValue)).map(&.to_s)
+            keys.each do |key|
+              yield Session.new(parse_session_id(key.as(String)))
+            end
+            break if cursor == "0"
+          end
+        end
+      end
+
+      macro define_delegators(vars)
+        {% for name, type in vars %}
+          def {{name.id}}(session_id : String, k : String) : {{type}}
+            load_into_cache(session_id) unless is_in_cache?(session_id)
+            return @cache.{{name.id}}(k)
+          end
+
+          def {{name.id}}?(session_id : String, k : String) : {{type}}?
+            load_into_cache(session_id) unless is_in_cache?(session_id)
+            return @cache.{{name.id}}?(k)
+          end
+
+          def {{name.id}}(session_id : String, k : String, v : {{type}})
+            load_into_cache(session_id) unless is_in_cache?(session_id)
+            @cache.{{name.id}}(k, v)
+            save_cache
+          end
+
+          def {{name.id}}s(session_id : String) : Hash(String, {{type}})
+            load_into_cache(session_id) unless is_in_cache?(session_id)
+            return @cache.{{name.id}}s
+          end
+        {% end %}
+      end
+
+      define_delegators({
         int: Int32,
         bigint: Int64,
         string: String,
         float: Float64,
         bool: Bool,
-        object: Session::StorableObject::StorableObjectContainer
+        object: Session::StorableObject::StorableObjectContainer,
       })
     end
-
-    @redis  : ConnectionPool(Redis)
-    @cache : StorageInstance
-    @cached_session_id : String
-
-    def initialize(host = "localhost", port = 6379, password = nil, database = 0, capacity = 20, timeout = 2.0, unixsocket = nil, pool = nil, key_prefix = "kemal:session:")
-      @redis = uninitialized ConnectionPool(Redis)
-
-      if pool.nil?
-        @redis = ConnectionPool.new(capacity: capacity, timeout: timeout) do
-          Redis.new(
-            host: host,
-            port: port,
-            database: database,
-            unixsocket: unixsocket,
-            password: password
-          )
-        end
-      else
-        @redis = pool.as(ConnectionPool(Redis))
-      end
-
-      @cache = StorageInstance.new
-      @key_prefix = key_prefix
-      @cached_session_id = ""
-    end
-
-    def run_gc
-      # Do Nothing. All the sessions should be set with the
-      # expiration option on the keys. So long as the redis instance
-      # hasn't been set up with maxmemory policy of noeviction
-      # then this should be fine. `noeviction` will cause the redis
-      # instance to fill up and keys will not expire from the instance
-    end
-
-    def prefix_session(session_id : String)
-      "#{@key_prefix}#{session_id}"
-    end
-
-    def parse_session_id(key : String)
-      key.sub(@key_prefix, "")
-    end
-
-    def load_into_cache(session_id)
-      @cached_session_id = session_id
-      conn = @redis.checkout
-      value = conn.get(prefix_session(session_id))
-      if !value.nil?
-        @cache = StorageInstance.from_json(value)
-      else
-        @cache = StorageInstance.new
-        conn.set(
-          prefix_session(session_id),
-          @cache.to_json,
-          ex: Session.config.timeout.total_seconds.to_i
-        )
-      end
-      @redis.checkin(conn)
-      return @cache
-    end
-
-    def save_cache
-      conn = @redis.checkout
-      conn.set(
-        prefix_session(@cached_session_id),
-        @cache.to_json,
-        ex: Session.config.timeout.total_seconds.to_i
-      )
-      @redis.checkin(conn)
-    end
-
-    def is_in_cache?(session_id)
-      return session_id == @cached_session_id
-    end
-
-    def create_session(session_id : String)
-      load_into_cache(session_id)
-    end
-
-    def get_session(session_id : String)
-      conn = @redis.checkout
-      value = conn.get(prefix_session(session_id))
-      @redis.checkin(conn)
-
-      return Session.new(session_id) if value
-      nil
-    end
-
-    def destroy_session(session_id : String)
-      conn = @redis.checkout
-      conn.del(prefix_session(session_id))
-      @redis.checkin(conn)
-    end
-
-    def destroy_all_sessions
-      conn = @redis.checkout
-
-      cursor = 0
-      loop do
-        cursor, keys = conn.scan(cursor, "#{@key_prefix}*")
-        keys = keys.as(Array(Redis::RedisValue)).map(&.to_s)
-        keys.each do |key|
-          conn.del(key)
-        end
-        break if cursor == "0"
-      end
-
-      @redis.checkin(conn)
-    end
-
-    def all_sessions
-      arr = [] of Session
-
-      each_session do |session|
-        arr << session
-      end
-
-      return arr
-    end
-
-    def each_session
-      conn = @redis.checkout
-
-      cursor = 0
-      loop do
-        cursor, keys = conn.scan(cursor, "#{@key_prefix}*")
-        keys = keys.as(Array(Redis::RedisValue)).map(&.to_s)
-        keys.each do |key|
-          yield Session.new(parse_session_id(key.as(String)))
-        end
-        break if cursor == "0"
-      end
-
-      @redis.checkin(conn)
-    end
-
-    macro define_delegators(vars)
-      {% for name, type in vars %}
-        def {{name.id}}(session_id : String, k : String) : {{type}}
-          load_into_cache(session_id) unless is_in_cache?(session_id)
-          return @cache.{{name.id}}(k)
-        end
-
-        def {{name.id}}?(session_id : String, k : String) : {{type}}?
-          load_into_cache(session_id) unless is_in_cache?(session_id)
-          return @cache.{{name.id}}?(k)
-        end
-
-        def {{name.id}}(session_id : String, k : String, v : {{type}})
-          load_into_cache(session_id) unless is_in_cache?(session_id)
-          @cache.{{name.id}}(k, v)
-          save_cache
-        end
-
-        def {{name.id}}s(session_id : String) : Hash(String, {{type}})
-          load_into_cache(session_id) unless is_in_cache?(session_id)
-          return @cache.{{name.id}}s
-        end
-      {% end %}
-    end
-
-    define_delegators({
-      int: Int32,
-      bigint: Int64,
-      string: String,
-      float: Float64,
-      bool: Bool,
-      object: Session::StorableObject::StorableObjectContainer,
-    })
   end
-end
 end

--- a/src/kemal-session-redis.cr
+++ b/src/kemal-session-redis.cr
@@ -67,15 +67,6 @@ module Kemal
             pool_size: capacity,
             pool_timeout: timeout
           )
-          # @redis = ConnectionPool.new(capacity: capacity, timeout: timeout) do
-          #   Redis.new(
-              # host: host,
-              # port: port,
-              # database: database,
-              # unixsocket: unixsocket,
-              # password: password
-          #   )
-          # end
         else
           @redis = pool
         end


### PR DESCRIPTION
Summary of changes:
- `stefanwille/crystal-redis` bumped to `~> 2.8.0`
  - Connection pooling is now built in the shard
  - Now using blocks syntax for connection pooling (replace checkout/checkin)
- No longer using the deprecated `JSON.mapping` macro
- Fix specs
- Added GitHub CI worklfow